### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Yashodha Lakshana
 maintainer=Yashodha Lakshana <yashodhalakshana@gmail.com>
 sentence=Arduino Library for BeeIR and all of other analog IR sensors
 paragraph=Arduino Library for BeeIR and all of other analog IR sensors. The Library can output analog sensors values as a boolean values. the sensor values is greater than programmer provided threshold value then output is 1 and sensor value is minor than threshold value then output is 0.
-category=Sensor
+category=Sensors
 url=https://github.com/yashodhalakshana/BeeIR-Sensor
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category 'Sensor' in library BeeIR sensor is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format